### PR TITLE
fix(ci): replace alliedmods.net system2 download with GitHub release

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,8 @@ jobs:
       run: |
         mkdir -p addons/sourcemod/plugins
 
-        wget "https://forums.alliedmods.net/attachment.php?attachmentid=188744&d=1618607414" -O system2.zip
+        wget "https://github.com/dordnung/System2/releases/download/v3.3.2/system2.zip" -O system2.zip
+        echo "0a6f47243e280a9afee390b0943f9cf7f27f4f6c5a813a5ef63fb30162fccf5b  system2.zip" | sha256sum -c
         unzip -o system2.zip -d addons/sourcemod/
 
     - name: Compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM melkortf/tf2-sourcemod:latest
 
-RUN wget "https://forums.alliedmods.net/attachment.php?attachmentid=188744&d=1618607414" -O system2.zip \
+RUN wget "https://github.com/dordnung/System2/releases/download/v3.3.2/system2.zip" -O system2.zip \
+  && echo "0a6f47243e280a9afee390b0943f9cf7f27f4f6c5a813a5ef63fb30162fccf5b  system2.zip" | sha256sum -c \
   && unzip -o system2.zip -d "${SERVER_DIR}/tf/addons/sourcemod/" \
   && rm -f system2.zip
 


### PR DESCRIPTION
## Summary

- Replaces the broken alliedmods.net forum attachment URL with the official GitHub release URL (v3.3.2) for the system2 extension
- Adds SHA256 checksum verification to ensure download integrity

## Reason

alliedmods.net added Cloudflare captcha protection, which causes the `wget` step in CI to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)